### PR TITLE
Update `npm` to `npx`

### DIFF
--- a/website/pages/docs/concepts/style-props.mdx
+++ b/website/pages/docs/concepts/style-props.mdx
@@ -62,7 +62,7 @@ Next, you need to run `panda codegen` to generate the JSX runtime for your frame
   </Tab>
   <Tab>
   ```bash
-  npm panda codegen --clean
+  npx panda codegen --clean
   ```
   </Tab>
   <Tab>


### PR DESCRIPTION
## 📝 Description

> In the jsx "style props" docs, `npm panda codegen --clean` returns an error -- it should be `npx panda codegen --clean`


## ⛳️ Current behavior (updates)

> Modifying documentation to specify `npx` instead of `npm`. Running the current command results in this error: 

```
> npm panda codegen --clean

Unknown command: "panda"

To see a list of supported npm commands, run:
  npm help
```

## 🚀 New behavior

> Running the command with `npx` will not generate an error, and will instead result in updated styled-system files: 

```
> npx panda codegen --clean

✔️ `styled-system/css`: the css function to author styles
✔️ `styled-system/tokens`: the css variables and js function to query your tokens
✔️ `styled-system/patterns`: functions to implement apply common layout patterns
✔️ `styled-system/jsx`: styled jsx elements for react 
```

## 💣 Is this a breaking change (Yes/No):

No

